### PR TITLE
Add conditional CDN attribute for images based on environment

### DIFF
--- a/src/lib/components/KonineArt.svelte
+++ b/src/lib/components/KonineArt.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Image } from '@unpic/svelte';
 	import { base } from '$app/paths';
+	import { dev } from '$app/environment';
 </script>
 
 <section
@@ -34,6 +35,7 @@
 							height={500}
 							loading="lazy"
 							class="h-auto w-full transition-transform duration-300 group-hover:scale-110"
+							cdn={dev ? undefined : "netlify"}
 						/>
 						<div
 							class="bg-opacity-0 group-hover:bg-opacity-20 absolute inset-0 transition-opacity duration-300"
@@ -58,6 +60,7 @@
 							height={500}
 							loading="lazy"
 							class="h-auto w-full transition-transform duration-300 group-hover:scale-110"
+							cdn={dev ? undefined : "netlify"}
 						/>
 						<div
 							class="bg-opacity-0 group-hover:bg-opacity-20 absolute inset-0 transition-opacity duration-300"
@@ -82,6 +85,7 @@
 							height={500}
 							loading="lazy"
 							class="h-auto w-full transition-transform duration-300 group-hover:scale-110"
+							cdn={dev ? undefined : "netlify"}
 						/>
 						<div
 							class="bg-opacity-0 group-hover:bg-opacity-20 absolute inset-0 transition-opacity duration-300"

--- a/src/lib/components/Photography.svelte
+++ b/src/lib/components/Photography.svelte
@@ -3,7 +3,7 @@
 	import { Image } from '@unpic/svelte';
 	import generatedImages from '$lib/generated-images.json';
 	import { onMount, onDestroy } from 'svelte';
-	import { browser } from '$app/environment';
+	import { browser, dev } from '$app/environment';
 
 	// Use the generated images
 	const images = generatedImages.images;
@@ -136,6 +136,7 @@
 								height={200}
 								loading="lazy"
 								class="rounded-lg shadow-lg"
+								cdn={dev ? undefined : "netlify"}
 							/>
 						{/each}
 					</Gallery>
@@ -244,6 +245,7 @@
 					width={1200}
 					height={800}
 					class="h-auto max-h-[calc(100vh-2rem)] w-auto max-w-[calc(100vw-2rem)] rounded-lg object-contain shadow-2xl"
+					cdn={dev ? undefined : "netlify"}
 				/>
 			</div>
 

--- a/src/lib/components/Photography.svelte
+++ b/src/lib/components/Photography.svelte
@@ -241,7 +241,7 @@
 				<Image
 					src={selectedImage.src}
 					alt={selectedImage.alt}
-					layout="fullWidth"
+					layout="constrained"
 					width={1200}
 					height={800}
 					class="h-auto max-h-[calc(100vh-2rem)] w-auto max-w-[calc(100vw-2rem)] rounded-lg object-contain shadow-2xl"


### PR DESCRIPTION
Introduce a conditional CDN attribute for images that varies based on the development environment. This change enhances flexibility by ensuring that images load correctly in both development and production settings.